### PR TITLE
build rocksdb with -Wno-format-truncation

### DIFF
--- a/rocksdb-haskell-kadena.cabal
+++ b/rocksdb-haskell-kadena.cabal
@@ -118,7 +118,6 @@ library
     -Wsign-compare
     -Wshadow
     -Wunused-parameter
-    -Werror
     -std=c++2a
     -faligned-new
     -DNO_THREEWAY_CRC32C


### PR DESCRIPTION
I think a gcc compiler upgrade started causing this to trigger, and changing the rocksdb source code is not something I think we should be doing