### PR TITLE
cabal: remove `-Werror` for cxx sources

### DIFF
--- a/rocksdb-haskell-kadena.cabal
+++ b/rocksdb-haskell-kadena.cabal
@@ -118,7 +118,6 @@ library
     -Wsign-compare
     -Wshadow
     -Wunused-parameter
-    -Werror
     -std=c++2a
     -faligned-new
     -DNO_THREEWAY_CRC32C


### PR DESCRIPTION
We can't control what C compiler the user has available, and `-Werror` effectively makes forward compatibility impossible. This is probably fixed in a newer RocksDB, but we haven't updated, so for now just live with what we have.